### PR TITLE
Issue 6 update vector tiles

### DIFF
--- a/Dockerfile/Dockerfile
+++ b/Dockerfile/Dockerfile
@@ -23,4 +23,5 @@ COPY script.sh .
 RUN chmod +x ./script.sh
 
 # Run the script when starting the container
-CMD [ "./script.sh" ]
+CMD [ "/bin/bash", "-c", "./script.sh" ]
+

--- a/Dockerfile/main.dockerfile
+++ b/Dockerfile/main.dockerfile
@@ -1,0 +1,26 @@
+# This Dockerfile is a mix of two documentation sources:
+# https://cloud.google.com/run/docs/quickstarts/jobs/build-create-shell#writing
+# https://cloud.google.com/run/docs/tutorials/gcloud#code-container
+
+# ----------
+
+# Use a gcloud image based on debian:buster-slim for a lean production container.
+# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+
+RUN apt-get update
+
+# Install GDAL for ogr2ogr
+RUN apt-get install -y gdal-bin
+
+# Execute next commands in the directory /workspace
+WORKDIR /workspace
+
+# Copy over the script to the /workspace directory
+COPY script.sh .
+
+# Just in case the script doesn't have the executable bit set
+RUN chmod +x ./script.sh
+
+# Run the script when starting the container
+CMD [ "./script.sh" ]

--- a/Dockerfile/main.py
+++ b/Dockerfile/main.py
@@ -1,0 +1,22 @@
+import json
+from google.cloud import storage
+
+# Create an empty GeoJSON FeatureCollection
+empty_geojson = {
+    "type": "FeatureCollection",
+    "features": []
+}
+
+# Save to a local file
+local_filename = "property_tile_info.geojson"
+with open(local_filename, "w") as f:
+    json.dump(empty_geojson, f, indent=4)
+
+# Upload to GCP `temp_data` bucket
+bucket_name = "musa5090s25-team5-temp_data"
+client = storage.Client()
+bucket = client.bucket(bucket_name)
+blob = bucket.blob(local_filename)
+blob.upload_from_filename(local_filename)
+
+print(f"Uploaded empty GeoJSON to gs://{bucket_name}/{local_filename}")

--- a/Dockerfile/script.sh
+++ b/Dockerfile/script.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -ex
+
+# Download the property_tile_info.geojson file from the temp bucket.
+gcloud storage cp \
+  gs://musa5090s25-team5-temp_data/property_tile_info.geojson \
+  ./property_tile_info.geojson
+
+# Convert the geojson file to a vector tileset in a folder named "properties".
+# The tile set will be in the range of zoom levels 12-18. See the ogr2ogr docs
+# at https://gdal.org/drivers/vector/mvt.html for more information.
+ogr2ogr \
+  -f MVT \
+  -dsco MINZOOM=12 \
+  -dsco MAXZOOM=18 \
+  -dsco COMPRESS=NO \
+  ./properties \
+  ./property_tile_info.geojson
+
+# Upload the vector tileset to the public bucket.
+gcloud storage cp \
+  --recursive \
+  ./properties \
+  gs://musa5090s25-team5-public/tiles

--- a/property_tile_info.geojson
+++ b/property_tile_info.geojson
@@ -1,0 +1,4 @@
+{
+    "type": "FeatureCollection",
+    "features": []
+}


### PR DESCRIPTION
# Description

Created the dockerfile that will update the property_tile_info.geojson for the vector tiles to be used for front end.

Resolves #6 

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Small fix/change
- [ ] Documentation

## What should the reviewer know?

This will update the property_tile_info.geojson.

## Post-merge follow-ups

To deploy this, I used the code that Sean Koh graciously provided:
//Creating repository
gcloud artifacts repositories create generate-property-map-tiles --repository-format=docker ` --location=us-central1

//Execute whenever docker build is changed 
gcloud builds submit `
-- region us-central1 `
--tage us-central1-docker.pkg.dev/musa5090s25-team5/generate-property-map-tiles/tiles-image:1

//Change to update/create depending on if the job already exists
gclous run jobs create generate-property-map-tiles ` --image us-central1-docker.pkg.dev/musa5090s25-team5/generate-property-map-tiles/tiles-image:1 `--service-account data-pipeline-user@musa5090s25-team5.iam.gserviceaccount.com ` --cpu 4` --memory 4Gi ` --region us-central1 --task-timeout 30m

// Run the gcloud function
gcloud run jobs execute generate-property-map-tiles --region=us-central1

- [x] No action required
- [ ] Actions required (specified below)
